### PR TITLE
Add tension documentary scene

### DIFF
--- a/scenes/fall_with_tension.py
+++ b/scenes/fall_with_tension.py
@@ -1,1 +1,65 @@
+from manim import *
+import numpy as np
+
+# Use Roboto for all text
+config.font = "Roboto"
+
+class FallWithTension(Scene):
+    def construct(self):
+        mass = 5  # kg
+        g = 9.8   # m/s^2
+        rope_length = 2
+        ceiling_start_y = 3
+        total_time = 4
+
+        t = ValueTracker(0.0)
+
+        def ceiling_y():
+            tau = t.get_value()
+            if tau <= 1.0:
+                return ceiling_start_y
+            dt = tau - 1.0
+            return ceiling_start_y - 0.5 * g * dt ** 2
+
+        def object_y():
+            return ceiling_y() - rope_length
+
+        ceiling = Rectangle(width=4, height=0.3, fill_opacity=1, color=GRAY)
+        obj = Square(side_length=0.5, fill_opacity=1, color=BLUE)
+
+        ceiling.add_updater(lambda m: m.move_to(UP * ceiling_y()))
+        obj.add_updater(lambda m: m.move_to(UP * object_y()))
+        rope = always_redraw(lambda: Line(ceiling.get_bottom(), obj.get_top(), color=WHITE))
+
+        mass_label = always_redraw(lambda: Text("5 kg", font_size=24).next_to(obj, RIGHT))
+
+        self.play(FadeIn(ceiling, obj, rope, mass_label))
+
+        # Axes for tension graph
+        ax = Axes(
+            x_range=[0, total_time, 1],
+            y_range=[0, mass * g + 1, mass * g / 2],
+            x_length=5,
+            y_length=3,
+        ).to_corner(UR)
+        ax_labels = ax.get_axis_labels(Text("t (s)"), Text("T (N)"))
+        self.play(Create(ax), FadeIn(ax_labels))
+
+        def tension_func(tau):
+            if tau <= 1.0:
+                return mass * g
+            else:
+                return 0.0
+
+        tension_graph = always_redraw(
+            lambda: ax.plot(
+                tension_func,
+                x_range=[0, max(t.get_value(), 0.001)],
+                color=RED,
+            )
+        )
+        self.play(FadeIn(tension_graph))
+
+        self.play(t.animate.set_value(total_time), run_time=total_time, rate_func=linear)
+        self.wait()
 

--- a/scenes/tension_documentary.py
+++ b/scenes/tension_documentary.py
@@ -1,0 +1,79 @@
+from manim import *
+import numpy as np
+
+# Use Roboto for all text
+config.font = "Roboto"
+
+class TensionDocumentary(Scene):
+    def construct(self):
+        title = Text("What is Tension?", font_size=72)
+        self.play(Write(title))
+        self.wait(1)
+        self.play(title.animate.to_corner(UL))
+
+        # Parameters
+        initial_mass = 1  # kg
+        final_mass = 5    # kg
+        total_time = 4    # seconds
+        g = 9.8
+        rope_length = 2
+
+        t_tracker = ValueTracker(0.0)
+
+        # Ceiling and object
+        ceiling = Rectangle(width=6, height=0.3, fill_opacity=1, color=GRAY)
+        ceiling.to_edge(UP)
+
+        def current_mass():
+            return initial_mass + (final_mass - initial_mass) * (t_tracker.get_value() / total_time)
+
+        def ball_mobject():
+            radius = 0.3 * current_mass()
+            return (
+                Circle(radius=radius, color=BLUE, fill_opacity=1)
+                .next_to(ceiling, DOWN, buff=rope_length)
+            )
+
+        ball = always_redraw(ball_mobject)
+        rope = always_redraw(lambda: Line(ceiling.get_bottom(), ball.get_top(), color=WHITE))
+        mass_label = always_redraw(
+            lambda: Text(f"{current_mass():.1f} kg", font_size=24).next_to(ball, RIGHT)
+        )
+
+        self.play(FadeIn(ceiling, ball, rope, mass_label))
+
+        # Tension formula
+        formula = Text("T = m g", font_size=48)
+        formula.next_to(title, DOWN)
+        self.play(Write(formula))
+
+        # Axes for tension graph
+        max_tension = final_mass * g
+        ax = Axes(
+            x_range=[0, total_time, 1],
+            y_range=[0, max_tension + g, max_tension / 5],
+            x_length=5,
+            y_length=3,
+        ).to_corner(UR)
+        ax_labels = ax.get_axis_labels(Text("t (s)"), Text("T (N)"))
+        self.play(Create(ax), FadeIn(ax_labels))
+
+        def tension_at(tau):
+            mass = initial_mass + (final_mass - initial_mass) * (tau / total_time)
+            return mass * g
+
+        tension_graph = always_redraw(
+            lambda: ax.plot(
+                tension_at,
+                x_range=[0, max(t_tracker.get_value(), 0.001)],
+                color=RED,
+            )
+        )
+        tension_dot = always_redraw(
+            lambda: Dot(ax.c2p(t_tracker.get_value(), tension_at(t_tracker.get_value())), color=YELLOW)
+        )
+
+        self.play(FadeIn(tension_graph, tension_dot))
+
+        self.play(t_tracker.animate.set_value(total_time), run_time=total_time, rate_func=linear)
+        self.wait(1)


### PR DESCRIPTION
## Summary
- create `TensionDocumentary` scene showing how tension changes with increasing weight
- display a ball growing in size while plotting tension vs time
- show the formula `T = m g`
- keep Roboto as default font

## Testing
- `python -m py_compile scenes/fall_with_tension.py scenes/tension_documentary.py`
- `manim -pql scenes/tension_documentary.py TensionDocumentary` *(fails to preview due to `xdg-open` missing but video renders)*

------
https://chatgpt.com/codex/tasks/task_e_686053e1bb84832198405cd2a261eaba